### PR TITLE
Implementing random and bypass accessibility rule

### DIFF
--- a/SonarAnalyzer.FSharp/src/SonarAnalyzer.FSharp/Rules/Hotspots/S3011_BypassingAccessibility.fs
+++ b/SonarAnalyzer.FSharp/src/SonarAnalyzer.FSharp/Rules/Hotspots/S3011_BypassingAccessibility.fs
@@ -3,13 +3,11 @@
 open SonarAnalyzer.FSharp
 open SonarAnalyzer.FSharp.RuleHelpers
 open FSharpAst
-open System.Net
 
 // =================================================
 // #3011 Changing or bypassing accessibility is security-sensitive
 // https://rules.sonarsource.com/csharp/type/Security%20Hotspot/RSPEC-3011
 // =================================================
-
 
 module Private =
 
@@ -18,11 +16,38 @@ module Private =
     let messageFormat = "Make sure that this accessibility bypass is safe here.";
     let rule = DiagnosticDescriptor.Create(DiagnosticId, messageFormat, RspecStrings.ResourceManager)
 
-    exception EarlyReturn
+    /// Checks to see if the constant for BindingFlags.NonPublic is ever used.
+    let checkForNonPublicFlag (ctx: TastContext) =
+        let isBindingFlags (t:FSharpAst.Tast.NamedType) =
+            let bindingFlagDescriptor : Tast.NamedTypeDescriptor = 
+                {
+                    AccessPath = "System.Reflection"
+                    CompiledName = "BindingFlags"
+                    DisplayName = "BindingFlags" 
+                }
+            t.Descriptor = bindingFlagDescriptor
+
+        let isNonPublic (constExpr:Tast.ConstantExpr) =
+            constExpr.Value = (32 |> box)
+
+        option {
+            let! call = ctx.Try<Tast.ConstantExpr>()
+            match call.Type with
+            | FSharpAst.Tast.NamedType t ->
+                let isFailure = isBindingFlags t && isNonPublic call
+
+                if isFailure then
+                    return! Diagnostic.Create(rule, call.Location, t.Descriptor.CompiledName) |> Some
+                else
+                    return! None
+            | _ -> return! None
+            }
 
 open Private
 
 /// The implementation of the rule
 [<Rule(DiagnosticId)>]
 let Rule : Rule = fun ctx ->
-    None
+    let rule =
+        checkForNonPublicFlag
+    rule ctx

--- a/SonarAnalyzer.FSharp/tests/SonarAnalyzer.FSharp.UnitTest/SourceFileTests.fs
+++ b/SonarAnalyzer.FSharp/tests/SonarAnalyzer.FSharp.UnitTest/SourceFileTests.fs
@@ -20,7 +20,6 @@ let S2092_CookieShouldBeSecure() =
     Verifier.verify @"TestCases\S2092_CookieShouldBeSecure.fs" rule
 
 [<Test>]
-[<Ignore("not implemented")>]
 let S2245_DoNotUseRandom() =
     let rule = Rules.S2245_DoNotUseRandom.Rule
     Verifier.verify @"TestCases\S2245_DoNotUseRandom.fs" rule

--- a/SonarAnalyzer.FSharp/tests/SonarAnalyzer.FSharp.UnitTest/SourceFileTests.fs
+++ b/SonarAnalyzer.FSharp/tests/SonarAnalyzer.FSharp.UnitTest/SourceFileTests.fs
@@ -31,7 +31,6 @@ let S2255_UsingCookies() =
     Verifier.verify @"TestCases\S2255_UsingCookies.fs" rule
 
 [<Test>]
-[<Ignore("not implemented")>]
 let S3011_BypassingAccessibility() =
     let rule = Rules.S3011_BypassingAccessibility.Rule
     Verifier.verify @"TestCases\S3011_BypassingAccessibility.fs" rule


### PR DESCRIPTION
Implemented the rule which checks for Random in the code.

Very simple rule, just looks for anything which calls a `System.Random` ctor.

----

Also implemented a rule that checks for `BindingFlags.NonPublic`