### PR TITLE
Update install instructions in README, small fix to build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Install SonarQube:
 
 Install the plugin:
 
-1. Download [the plugin `sonar-fsharpsecurity-plugin.jar` file from Appveyor](https://ci.appveyor.com/project/swlaschin/sonar-fsharpsecurity-plugin/build/artifacts).
-1. Shut down SonarQube, then copy the plugin `sonar-fsharpsecurity-plugin.jar` file to the [SonarQube plugins directory](https://docs.sonarqube.org/latest/setup/install-plugin/) and restart SonarQube.
+1. Follow the  [instructions for building the SonarQube plugin](docs/contributing-plugin.md), which will produce the plugin `sonar-fsharpsecurity-plugin-${version}.jar`.
+1. Shut down SonarQube, then copy the plugin `sonar-fsharpsecurity-plugin-${version}.jar` file *without* the version suffix to the [SonarQube plugins directory](https://docs.sonarqube.org/latest/setup/install-plugin/) and restart SonarQube.
 
 Prepare for using SonarScanner:
 

--- a/SonarAnalyzer.FSharp/zip-assembly.xml
+++ b/SonarAnalyzer.FSharp/zip-assembly.xml
@@ -8,7 +8,7 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>src/FsSonarRunner/publish</directory>
+      <directory>publish</directory>
       <outputDirectory>\</outputDirectory>
       <includes>
         <include>win-x86/**</include>


### PR DESCRIPTION
The jar file seems to no longer be available on appveyor, so I updated the readme. I also had to update a path in zip-assembly.xml to compile the jar.