### PR TITLE
Fix utf8 bom issues with XML and update to .NET Core 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+Originally, this plugin was hosted on https://github.com/swlaschin/sonar-fsharpsecurity-plugin. However, 
+[Scott Wlaschin has commented](https://github.com/jmecosta/sonar-fsharp-plugin/issues/96#issuecomment-630816652) 
+that he won't be maintaining this project anymore. 
+
+The `sonar-fsharpsecurity-plugin` dir contains the original plugin code plus the changes needed for it to compile
+and to make it work with SonarQube.
+
+Original content follows:
+
 # sonar-fsharpsecurity-plugin
 
 sonar-fsharpsecurity-plugin is a F# plugin for SonarQube focused on security/vuln scanning only.

--- a/SonarAnalyzer.FSharp/src/FsSonarRunner/FsSonarRunner.fsproj
+++ b/SonarAnalyzer.FSharp/src/FsSonarRunner/FsSonarRunner.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SonarAnalyzer.FSharp/src/FsSonarRunner/Utilities.fs
+++ b/SonarAnalyzer.FSharp/src/FsSonarRunner/Utilities.fs
@@ -12,7 +12,8 @@ open System.Text
 let logger = Serilog.Log.Logger
 
 let serializeToXmlFile filePath (objectToSerialize:obj) =
-    let settings = XmlWriterSettings(Indent = true,Encoding = Encoding.UTF8,IndentChars = "  ")
+    let settings = XmlWriterSettings(Indent = true,Encoding = new UTF8Encoding(false),IndentChars = "  ")
+    
     let serializer = new XmlSerializer(objectToSerialize.GetType())
     let namespaces = XmlSerializerNamespaces [|XmlQualifiedName.Empty |]
 

--- a/SonarAnalyzer.FSharp/tests/FSharpAst.UnitTest/FSharpAst.UnitTest.fsproj
+++ b/SonarAnalyzer.FSharp/tests/FSharpAst.UnitTest/FSharpAst.UnitTest.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/SonarAnalyzer.FSharp/tests/SonarAnalyzer.FSharp.UnitTest/SonarAnalyzer.FSharp.UnitTest.fsproj
+++ b/SonarAnalyzer.FSharp/tests/SonarAnalyzer.FSharp.UnitTest/SonarAnalyzer.FSharp.UnitTest.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SonarAnalyzer.FSharp/zip-assembly.xml
+++ b/SonarAnalyzer.FSharp/zip-assembly.xml
@@ -8,7 +8,7 @@
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>
     <fileSet>
-      <directory>src/FsSonarRunner/publish</directory>
+      <directory>publish</directory>
       <outputDirectory>\</outputDirectory>
       <includes>
         <include>win-x86/**</include>

--- a/SonarAnalyzer.FSharp/zip-assembly.xml
+++ b/SonarAnalyzer.FSharp/zip-assembly.xml
@@ -9,7 +9,7 @@
   <fileSets>
     <fileSet>
       <directory>publish</directory>
-      <outputDirectory>\</outputDirectory>
+      <outputDirectory>/</outputDirectory>
       <includes>
         <include>win-x86/**</include>
         <include>linux-x86/**</include>

--- a/sonar-fsharpsecurity-plugin/src/main/resources/rules.xml
+++ b/sonar-fsharpsecurity-plugin/src/main/resources/rules.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <rules>
   <rule>
     <key>S5042</key>


### PR DESCRIPTION
Fixes #9.
Fixes #8.

This PR fixes the UTF-8 XML reader issues with Java that prevents the output of the plugin to be read by SonarQube.

It also fixes the ZIP creation (see also PR #6, it has the same fix) and updates the projects to .NET Core 3.1.